### PR TITLE
Wrong read number value

### DIFF
--- a/Source/TonSwift/TVM/TupleReader.swift
+++ b/Source/TonSwift/TVM/TupleReader.swift
@@ -51,7 +51,13 @@ public class TupleReader {
     }
     
     public func readNumber() throws -> UInt64 {
-        return UInt64(try readBigNumber())
+        let popedBigNumber = try readBigNumber()
+        
+        guard popedBigNumber >= 0 else {
+            throw TonError.custom("Wrong number")
+        }
+        
+        return UInt64(popedBigNumber)
     }
     
     public func readNumberOpt() throws -> UInt64? {


### PR DESCRIPTION
<img width="1243" alt="Снимок экрана 2024-08-15 в 10 42 03" src="https://github.com/user-attachments/assets/54eaba7c-f4b8-49b8-93cd-c9b7f444cc3a">

Прикладываю стек краша. Полагаю проблема была именно в этом, что не корректно получалось число из BigInt. Более значительные изменения страшно делать. По наблюдениям краш только у одного пользователя.